### PR TITLE
Added query for Alma bib info using barcode

### DIFF
--- a/lib/berkeley_library/alma/barcode.rb
+++ b/lib/berkeley_library/alma/barcode.rb
@@ -1,0 +1,45 @@
+require 'berkeley_library/alma/record_id'
+
+module BerkeleyLibrary
+  module Alma
+    # {RecordId} subclass representing an item barcode.
+    class BarCode
+      include RecordId
+
+      attr_reader :barcode
+
+      # Initialize a barcode. Since we purchase barcodes of varied formats and accept vendor
+      # barcodes as well we are only validating whether it's a string or not.
+      def initialize(barcode)
+        string?(barcode)
+        @barcode = barcode
+      end
+
+      # Returns the SRU query value for this Barcode.
+      #
+      # @return [String] the Barcode query value
+      def sru_query_value
+        "alma.barcode=#{@barcode}"
+      end
+
+      # Returns the permalink URI for this barcode.
+      # Requires {Config#alma_permalink_base_uri} to be set.
+      #
+      # @return [URI] the permalink URI.
+      def permalink_uri
+        URIs.append(permalink_base_uri, "alma#{barcode}")
+      end
+
+      private
+
+      def permalink_base_uri
+        Config.alma_permalink_base_uri
+      end
+
+      def string?(barcode)
+        raise ArgumentError, "Barcode must be a string: #{barcode.inspect}" unless barcode.is_a?(String)
+      end
+
+    end
+  end
+end

--- a/spec/data/C084093187-sru.xml
+++ b/spec/data/C084093187-sru.xml
@@ -1,0 +1,299 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><searchRetrieveResponse xmlns="http://www.loc.gov/zing/srw/">
+  <version>1.2</version>
+  <numberOfRecords>1</numberOfRecords>
+  <records>
+    <record>
+      <recordSchema>marcxml</recordSchema>
+      <recordPacking>xml</recordPacking>
+      <recordData>
+        <record xmlns="http://www.loc.gov/MARC21/slim">
+          <leader>03480cgm a2200781Mi 4500</leader>
+          <controlfield tag="001">991039354509706532</controlfield>
+          <controlfield tag="005">20210615124013.0</controlfield>
+          <controlfield tag="007">vd cvaizs</controlfield>
+          <controlfield tag="008">050601p19971996quc135            vleng d</controlfield>
+          <datafield ind1="1" ind2=" " tag="024">
+            <subfield code="a">774212007033</subfield>
+          </datafield>
+          <datafield ind1="4" ind2="2" tag="028">
+            <subfield code="a">20070</subfield>
+            <subfield code="b">Seville Pictures</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="035">
+            <subfield code="a">(OCoLC)613118288</subfield>
+            <subfield code="z">(OCoLC)800045975</subfield>
+            <subfield code="z">(OCoLC)811619021</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="035">
+            <subfield code="a">(CLU)8266514-ucladb-Voyager</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="035">
+            <subfield code="a">(EXLNZ-01UCS_NETWORK)9912724001006531</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="040">
+            <subfield code="a">W2U</subfield>
+            <subfield code="b">eng</subfield>
+            <subfield code="c">W2U</subfield>
+            <subfield code="d">OCLCF</subfield>
+            <subfield code="d">OCLCO</subfield>
+            <subfield code="d">TOH</subfield>
+            <subfield code="d">GK8</subfield>
+            <subfield code="d">OCL</subfield>
+            <subfield code="d">OCLCQ</subfield>
+            <subfield code="d">OCLCO</subfield>
+            <subfield code="e">rda</subfield>
+            <subfield code="d">CDS</subfield>
+            <subfield code="d">OCLCA</subfield>
+          </datafield>
+          <datafield ind1="1" ind2=" " tag="041">
+            <subfield code="a">eng</subfield>
+            <subfield code="a">fre</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="043">
+            <subfield code="a">n-us---</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="044">
+            <subfield code="a">quc</subfield>
+            <subfield code="a">xxu</subfield>
+            <subfield code="a">fr</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="046">
+            <subfield code="k">1996</subfield>
+          </datafield>
+          <datafield ind1="1" ind2="4" tag="050">
+            <subfield code="a">PN1997</subfield>
+            <subfield code="b">.L735 1997</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="090">
+            <subfield code="b">DVD 3916</subfield>
+            <subfield code="9">LOCAL</subfield>
+          </datafield>
+          <datafield ind1="0" ind2="0" tag="245">
+            <subfield code="a">Lost highway /</subfield>
+            <subfield code="c">October Films presents a CIBY 2000/Asymmetrical production ; a David Lynch film ; produced by Deepak Nayar, Tom Sternberg, Mahy Sweeney ; written by David Lynch &amp; Barry Gifford ; directed by David Lynch.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="257">
+            <subfield code="a">United States</subfield>
+            <subfield code="a">France</subfield>
+            <subfield code="2">naf</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="1" tag="264">
+            <subfield code="a">[Montreal] :</subfield>
+            <subfield code="b">Seville Pictures,</subfield>
+            <subfield code="c">1997.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="300">
+            <subfield code="a">1 videodisc (135 min.) :</subfield>
+            <subfield code="b">sound, color ;</subfield>
+            <subfield code="c">4 3/4 in.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="336">
+            <subfield code="a">two-dimensional moving image</subfield>
+            <subfield code="b">tdi</subfield>
+            <subfield code="2">rdacontent</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="337">
+            <subfield code="a">video</subfield>
+            <subfield code="b">v</subfield>
+            <subfield code="2">rdamedia</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="338">
+            <subfield code="a">videodisc</subfield>
+            <subfield code="b">vd</subfield>
+            <subfield code="2">rdacarrier</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="344">
+            <subfield code="a">digital</subfield>
+            <subfield code="b">optical</subfield>
+            <subfield code="g">stereo</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="346">
+            <subfield code="b">NTSC</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="347">
+            <subfield code="a">video file</subfield>
+            <subfield code="b">DVD video</subfield>
+            <subfield code="e">Region 1</subfield>
+            <subfield code="2">rda</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="380">
+            <subfield code="a">Motion picture</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="500">
+            <subfield code="a">Pan and scan version.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="500">
+            <subfield code="a">Special features include: theatrical trailer; interactive menus; scene selection.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="500">
+            <subfield code="a">Originally released as a motion picture in 1996.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="508">
+            <subfield code="a">Music, Angelo Badalamenti ; editor, Mary Sweeney ; director of photography, Peter Deming.</subfield>
+          </datafield>
+          <datafield ind1="1" ind2=" " tag="511">
+            <subfield code="a">Bill Pullman, Patricia Arquette, Balthazar Getty, Robert Blake, Natasha Gregson Wagner, Gary Busey, Robert Loggia.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="520">
+            <subfield code="a">A successful jazz musician whose marriage is on the rocks, a man in black who threatens to expose him, a young mechanic with links to a mobster, and the mobster's moll are all riders on the lost highway, trapped in their worlds of desire, destiny and unknown destination where the truth is always a short way further down the road.</subfield>
+          </datafield>
+          <datafield ind1="8" ind2=" " tag="521">
+            <subfield code="a">Canadian home video rating: R.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="538">
+            <subfield code="a">DVD, Dolby stereo; Region 1; NTSC.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="546">
+            <subfield code="a">In English or dubbed French.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="0" tag="650">
+            <subfield code="a">Jazz musicians</subfield>
+            <subfield code="z">United States</subfield>
+            <subfield code="v">Drama.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="7" tag="650">
+            <subfield code="a">Jazz musicians.</subfield>
+            <subfield code="2">fast</subfield>
+            <subfield code="0">(OCoLC)fst00982205</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="7" tag="651">
+            <subfield code="a">United States.</subfield>
+            <subfield code="2">fast</subfield>
+            <subfield code="0">(OCoLC)fst01204155</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="7" tag="655">
+            <subfield code="a">Drama.</subfield>
+            <subfield code="2">fast</subfield>
+            <subfield code="0">(OCoLC)fst01423879</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="7" tag="655">
+            <subfield code="a">Feature films.</subfield>
+            <subfield code="2">fast</subfield>
+            <subfield code="0">(OCoLC)fst01710384</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="7" tag="655">
+            <subfield code="a">Fiction films.</subfield>
+            <subfield code="2">fast</subfield>
+            <subfield code="0">(OCoLC)fst01710264</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="7" tag="655">
+            <subfield code="a">Feature films.</subfield>
+            <subfield code="2">lcgft</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="7" tag="655">
+            <subfield code="a">Fiction films.</subfield>
+            <subfield code="2">lcgft</subfield>
+          </datafield>
+          <datafield ind1="1" ind2=" " tag="700">
+            <subfield code="a">Pullman, Bill,</subfield>
+            <subfield code="e">actor.</subfield>
+          </datafield>
+          <datafield ind1="1" ind2=" " tag="700">
+            <subfield code="a">Arquette, Patricia,</subfield>
+            <subfield code="d">1968-</subfield>
+            <subfield code="e">actor.</subfield>
+          </datafield>
+          <datafield ind1="1" ind2=" " tag="700">
+            <subfield code="a">Getty, Balthazar,</subfield>
+            <subfield code="e">actor.</subfield>
+          </datafield>
+          <datafield ind1="1" ind2=" " tag="700">
+            <subfield code="a">Blake, Robert,</subfield>
+            <subfield code="d">1933-</subfield>
+            <subfield code="e">actor.</subfield>
+          </datafield>
+          <datafield ind1="1" ind2=" " tag="700">
+            <subfield code="a">Wagner, Natasha Gregson,</subfield>
+            <subfield code="d">1970-</subfield>
+            <subfield code="e">actor.</subfield>
+          </datafield>
+          <datafield ind1="1" ind2=" " tag="700">
+            <subfield code="a">Busey, Gary,</subfield>
+            <subfield code="e">actor.</subfield>
+          </datafield>
+          <datafield ind1="1" ind2=" " tag="700">
+            <subfield code="a">Loggia, Robert,</subfield>
+            <subfield code="e">actor.</subfield>
+          </datafield>
+          <datafield ind1="1" ind2=" " tag="700">
+            <subfield code="a">Nayar, Deepak.</subfield>
+            <subfield code="e">film producer.</subfield>
+          </datafield>
+          <datafield ind1="1" ind2=" " tag="700">
+            <subfield code="a">Sternberg, Tom.</subfield>
+            <subfield code="e">film producer.</subfield>
+          </datafield>
+          <datafield ind1="1" ind2=" " tag="700">
+            <subfield code="a">Sweeney, Mahy.</subfield>
+            <subfield code="e">film produer</subfield>
+          </datafield>
+          <datafield ind1="1" ind2=" " tag="700">
+            <subfield code="a">Lynch, David,</subfield>
+            <subfield code="d">1946-</subfield>
+            <subfield code="e">screenwriter,</subfield>
+            <subfield code="e">director.</subfield>
+          </datafield>
+          <datafield ind1="1" ind2=" " tag="700">
+            <subfield code="a">Gifford, Barry,</subfield>
+            <subfield code="d">1946-</subfield>
+            <subfield code="e">screenwriter.</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="710">
+            <subfield code="a">Séville Pictures.</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="710">
+            <subfield code="a">Asymmetrical (Firm)</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="710">
+            <subfield code="a">CIBY 2000 (Firm)</subfield>
+          </datafield>
+          <datafield ind1="2" ind2=" " tag="710">
+            <subfield code="a">October Films.</subfield>
+          </datafield>
+          <datafield ind1="4" ind2="2" tag="956">
+            <subfield code="z">Credits from Internet Movie Database</subfield>
+            <subfield code="u">http://www.imdb.com/title/tt0116922/</subfield>
+            <subfield code="9">LOCAL</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="968">
+            <subfield code="a">Reclvl: f Addate: 050601 Addid: SMI Moddate: 090214 Modid: MRC</subfield>
+            <subfield code="9">LOCAL</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="996">
+            <subfield code="e">GLADN151847889</subfield>
+            <subfield code="9">LOCAL</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="996">
+            <subfield code="a">b111084751</subfield>
+            <subfield code="b">Updated: 06-14-21</subfield>
+            <subfield code="c">Created: 03-17-09</subfield>
+            <subfield code="d">CatDate: 06-01-05</subfield>
+            <subfield code="9">LOCAL</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="AVA">
+            <subfield code="0">991039354509706532</subfield>
+            <subfield code="8">22725145850006532</subfield>
+            <subfield code="a">01UCS_BER</subfield>
+            <subfield code="b">MRC</subfield>
+            <subfield code="c">Media Resources Center</subfield>
+            <subfield code="d">DVD 3916</subfield>
+            <subfield code="e">available</subfield>
+            <subfield code="f">1</subfield>
+            <subfield code="g">0</subfield>
+            <subfield code="i">UCB_Campus</subfield>
+            <subfield code="j">mc</subfield>
+            <subfield code="k">8</subfield>
+            <subfield code="p">1</subfield>
+            <subfield code="q">Media Resources Center</subfield>
+          </datafield>
+        </record>
+      </recordData>
+      <recordIdentifier>991039354509706532</recordIdentifier>
+      <recordPosition>1</recordPosition>
+    </record>
+  </records>
+  <extraResponseData xmlns:xb="http://www.exlibris.com/repository/search/xmlbeans/">
+    <xb:exact>true</xb:exact>
+    <xb:responseDate>2022-02-10T12:40:32-0800</xb:responseDate>
+  </extraResponseData>
+</searchRetrieveResponse>

--- a/spec/lib/berkeley_library/alma/barcode_spec.rb
+++ b/spec/lib/berkeley_library/alma/barcode_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+module BerkeleyLibrary
+  module Alma
+    describe BarCode do
+      before(:each) do
+        BerkeleyLibrary::Alma.configure do
+          Config.alma_sru_host = 'berkeley.alma.exlibrisgroup.com'
+          Config.alma_institution_code = '01UCS_BER'
+          Config.alma_primo_host = 'search.library.berkeley.edu'
+          Config.alma_permalink_key = 'iqob43'
+        end
+      end
+
+      after(:each) do
+        BerkeleyLibrary::Alma::Config.send(:clear!)
+      end
+
+      describe :new do
+        bad_barcode = 1234
+        it "raises an error for input that's not an string" do
+          expect { BarCode.new(bad_barcode) }.to raise_error(ArgumentError), "#{bad_barcode}: No error raised for #{bad_barcode}"
+        end
+      end
+
+      describe :marc_record do
+        it 'returns the MARC record' do
+          barcode_id = 'C084093187'
+          stub_sru_request(barcode_id, 'barcode')
+
+          barcode = BerkeleyLibrary::Alma::BarCode.new(barcode_id)
+          marc_record = barcode.get_marc_record
+          expect(marc_record).not_to be_nil
+        end
+
+        it 'returns nil for an empty response' do
+          empty_sru_response = <<~XML.strip
+            <?xml version="1.0" encoding="UTF-8"?>
+            <searchRetrieveResponse>
+              <version>1.2</version>
+              <numberOfRecords>0</numberOfRecords>
+              <records/>
+            </searchRetrieveResponse>
+          XML
+
+          barcode_id = '991054360089706532doesntexist'
+          sru_url = sru_url_for(barcode_id, 'barcode')
+          stub_request(:get, sru_url).to_return(status: 200, body: empty_sru_response)
+
+          barcode = BarCode.new(barcode_id)
+          marc_record = barcode.get_marc_record
+          expect(marc_record).to be_nil
+        end
+
+        it 'returns nil for an HTTP error response' do
+          barcode_id = '991054360089706532934j3h'
+          sru_url = sru_url_for(barcode_id, 'barcode')
+          stub_request(:get, sru_url).to_return(status: 404)
+
+          barcode = BarCode.new(barcode_id)
+          marc_record = barcode.get_marc_record
+          expect(marc_record).to be_nil
+        end
+      end
+
+      describe :permalink_uri do
+        it 'returns the permalink' do
+          barcode_id = 'C084093187'
+          expected_url = "https://search.library.berkeley.edu/permalink/01UCS_BER/iqob43/alma#{barcode_id}"
+
+          barcode = BarCode.new(barcode_id)
+          expected_uri = URI.parse(expected_url)
+          expect(barcode.permalink_uri).to eq(expected_uri)
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,7 @@ require 'berkeley_library/alma'
 # ------------------------------------------------------------
 # Utility methods
 
-def sru_url_for(record_id)
+def sru_url_for(record_id, sru_type = nil)
   sru_url_base = 'https://berkeley.alma.exlibrisgroup.com/view/sru/01UCS_BER?version=1.2&operation=searchRetrieve&query='
 
   if BerkeleyLibrary::Alma::Constants::ALMA_RECORD_RE =~ record_id
@@ -39,6 +39,8 @@ def sru_url_for(record_id)
   elsif BerkeleyLibrary::Alma::Constants::MILLENNIUM_RECORD_RE =~ record_id
     full_bib_number = BerkeleyLibrary::Alma::BibNumber.new(record_id).to_s
     "#{sru_url_base}alma.local_field_996%3D#{full_bib_number}"
+  elsif sru_type.eql? 'barcode'
+    "#{sru_url_base}alma.barcode%3D#{record_id}"
   else
     raise ArgumentError, "Unknown record ID type: #{record_id}"
   end
@@ -48,8 +50,8 @@ def sru_data_path_for(record_id)
   "spec/data/#{record_id}-sru.xml"
 end
 
-def stub_sru_request(record_id)
-  sru_url = sru_url_for(record_id)
+def stub_sru_request(record_id, sru_type = nil)
+  sru_url = sru_url_for(record_id, sru_type)
   marc_xml_path = sru_data_path_for(record_id)
 
   stub_request(:get, sru_url).to_return(status: 200, body: File.read(marc_xml_path))


### PR DESCRIPTION
This is to add the ability to retrieve Alma bib info using the barcode. Unfortunately since barcodes have numerous variations (and we also get barcodes from vendors) there's very little to validate a barcode.  sru_query_value  and permalink_uri are basically duplicated in mmsid so they should probably be moved to a shared utility at some point. 

spec_helper is starting to look kind of sloppy with the three different options.